### PR TITLE
Fix incorrect description

### DIFF
--- a/storyscript/semantics/README.md
+++ b/storyscript/semantics/README.md
@@ -199,7 +199,7 @@ A story may [execute in many ways](/faq/#how-are-storyscripts-started).
 ```coffeescript
 translated = service action translate:my_string to:'spanish'
 parts = translated split by:' '
-service_b action name:parts[0]
+first_word = name:parts[0]
 ```
 
 The Story above is would perform the following operations:


### PR DESCRIPTION
The example in execution semantics did not match the description.  I opted to (hopefully correctly) update the example rather than explain the original text (`service_b action name:parts[0]`).