### PR TITLE
Update CLI instructions for story

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -14,12 +14,8 @@ To get started install the Storyscript CLI ([Contribute](https://github.com/stor
 brew install storyscript/brew/story
 ```
 
-<small>Also available via download:</small>
-
-<div><a href="https://github.com/storyscript/cli/releases/download/0.0.6/asyncy-0.0.6.pkg" class="button is-primary is-small">Download the installer</a></div>
-
-
 </td>
+<!--
 <td style="text-align:center" width="50%" valign="top">
 <h1><img src="../assets/windows-logo.svg" width="24"> Windows</h1>
 
@@ -28,13 +24,14 @@ Download the appropriate installer:
 <div><a href="https://github.com/storyscript/cli/releases/download/0.0.6/asyncy-x64.exe" class="button is-primary is-small">64-bit installer</a></div>
 
 </td>
+-->
 </tr>
 <tr>
 <td style="text-align:center" valign="top">
 <h1><img src="../assets/ubuntu-logo.svg" width="24"> Ubuntu 16+</h1>
 
 ```shell
-sudo snap install asyncy --classic
+sudo snap install story
 ```
 
 <small><a href="https://snapcraft.io/">Snap is available on other Linux OS.</a></small>
@@ -47,6 +44,7 @@ sudo snap install asyncy --classic
 pip install --user story
 ```
 
+Python 3.6 or higher is required, thus on Debian/Ubuntu use `pip3`.
 The other installation methods listed are recommended.
 
 </td>

--- a/quick-start/README.md
+++ b/quick-start/README.md
@@ -43,7 +43,7 @@ Download the appropriate installer:
 <summary><h4><img src="../assets/ubuntu-logo.svg" width="15"> Ubuntu 16+</h4></summary>
 
 ```shell
-sudo snap install asyncy --classic
+sudo snap install story
 ```
 
 <small><a href="https://snapcraft.io/">Snap is available on other Linux OS.</a></small>
@@ -58,7 +58,8 @@ sudo snap install asyncy --classic
 pip install --user story
 ```
 
-We **strongly recommend** using the other installation techniques.
+Python 3.6 or higher is required, thus on Debian/Ubuntu use `pip3`.
+The other installation methods listed are recommended.
 
 </details>
 </td>


### PR DESCRIPTION
Currently it looks a bit weird though:

![image](https://user-images.githubusercontent.com/4370550/58168301-35b89400-7c8e-11e9-9988-9c98b16303a4.png)

I created a separate issue for this: https://github.com/storyscript/docs.storyscript.io/issues/73, but we should probably wait with merging/deploying this until the styling looks nice.

Also the snap package doesn't exist yet, so don't merge this just yet.