### PR TITLE
Rebrand mutations as built-ins

### DIFF
--- a/storyscript/functions/README.md
+++ b/storyscript/functions/README.md
@@ -48,72 +48,83 @@ output = functionA(key:(functionB(key:(functionC(...)))))
 
 Functions MUST be used to produce inline functions. The innermost parentheses will be executed first moving out to the outermost.
 
-Same level parentheses MAY be called at the same time which done by parallel processing in new threads.
+Same level parentheses MAY be called at the same time which could be done by parallel processing in new threads.
 
-First set of parentheses when assigning variables is optional. E.g., `a = my_list length` is the same as `a = (my_list length)`.
+Furthermore, the first set of parentheses when assigning variables is optional. E.g., `a = functionA()` is the same as `a = (functionA())`.
 
-### Mutations
-Mutations refer to running operations on the built in data types, such as strings, arrays, maps, and numbers.
+## Built-ins
+
+Built-ins refer to running operations on the built-in data types, such as strings, lists, maps, and numbers.
+
+### Strings
+
 ```coffeescript
-# Strings
 # Note: None of the string operations below change the original string in any form
 str = ''
-str length  # returns the number of UTF-8 characters
-str replace pattern: 'ab' by: 'AB'  # returns a string by replacing 'ab' with 'AB'
-str replace pattern: /ab/ by: 'AB'  # same as above
-str split by: '.'  # returns an array by splitting the string with the delimiter
-str uppercase  # returns a string where all characters are upper cased
-str lowercase  # returns a string where all characters are lower cased
-str capitalize  # returns a string where the first letter of each word is capitalized (eg: 'jane smith' becomes 'Jane Smith')
-
-# Numbers
-num = 10
-num is_odd  # returns false
-num is_even  # returns true
-num absolute  # returns the absolute value (if num was -1, this would return 1)
-num increment  # returns 11. Note that num is not changed
-num decrement  # returns 9. Note that num is not changed
-
-# Arrays
-arr = [1, 2, 3, 4, 5]
-arr index of: 5  # returns the index of an element, 4 in this case
-arr length  # returns the length of the array, 5 in this case
-arr append item: 6  # adds 6 to the end of the array
-arr prepend item: 1  # adds 1 to the start of the array
-arr random  # returns a random element from this array
-arr reverse  # reverses the array in-place
-arr sort  # sorts the array in an ascending fashion
-arr min  # returns the lowest of the elements in this array (if it contains numbers)
-arr max  # returns the largest of the elements in this array (if it contains numbers)
-arr sum  # returns the sum of all the elements in this array (if it contains numbers)
-arr unique  # reduces the array to contain only unique items
-arr contains item: 3  # returns true if 3 is present, false otherwise
-arr remove item: 3  # removes the item specified from the array
-
-# Maps
-m = {'a': 1, 'b': 2}
-m size  # returns the size of the map, 2 in this case
-m keys  # returns an array of all keys
-m values  # returns an array of all values
-m flatten  # returns a list of key/value pairs (eg: [['a', 1], ['b', 2]])
-m pop key: 'a'  # removes and returns the value for key 'a'
-m get key: 'b'  # returns the value for the key 'b'
-m contains key: 'c'  # returns true if the key 'c' exists in the map, false otherwise
+str.length()  # returns the number of UTF-8 characters
+str.replace(item: 'ab' by: 'AB')  # returns a string by replacing 'ab' with 'AB'
+str.replace(pattern: /ab/ by: 'AB')  # replace all occurrences of the pattern RegExp /ab/ with 'ab'
+str.split(by: '.')  # returns a list by splitting the string with the delimiter
+str.uppercase()  # returns a string where all characters are upper cased
+str.lowercase()  # returns a string where all characters are lower cased
+str.capitalize()  # returns a string where the first letter of each word is capitalized (eg: 'jane smith' becomes 'Jane Smith')
+str.trim() # returns a string with any leading and trailing whitespace (including tabs) removed
+str.startswith(prefix: 'abc') # returns true if the string starts with the prefix 'abc'
+str.endswith(suffix: 'xyz') # returns true if the string ends with the suffix 'xyz'
+arr.contains(item: 'a')  # returns true if the item 'a' occurrs in the string, false otherwise
+arr.contains(pattern: /a/)  # returns true if the RegExp /a/ occurrs in the string, false otherwise
 ```
 
-### Chaining Mutations
-
-Mutations can be chained to help reduce complexity.
+### Numbers
 
 ```coffeescript
-'abc' uppercase split
-# >>> ['A', 'B', 'C']
-
-'abc' uppercase
-      then split
-# >>> ['A', 'B', 'C']
-
-('abc' uppercase) split
-# >>> ['A', 'B', 'C']
+num = 10
+num.is_odd()  # returns false
+num.is_even()  # returns true
+num.absolute()  # returns the absolute value (if num was -1, this would return 1)
+num.increment()  # returns 11. Note that num is not changed
+num.decrement()  # returns 9. Note that num is not changed
 ```
 
+### Lists
+
+```coffeescript
+arr = [1, 2, 3, 4, 5]
+arr.index(of: 5)  # returns the index of an element, 4 in this case
+arr.length()  # returns the length of the list, 5 in this case
+arr.append(item: 6)  # adds 6 to the end of the list
+arr.prepend(item: 1)  # adds 1 to the start of the list
+arr.random()  # returns a random element from this list
+arr.reverse()  # returns the list in reverse-order
+arr.sort()  # returns the list in an ascending fashion
+arr.min()  # returns the lowest of the elements in this list (if it contains numbers)
+arr.max()  # returns the largest of the elements in this list (if it contains numbers)
+arr.sum()  # returns the sum of all the elements in this list (if it contains numbers)
+arr.unique()  # reduces the list to contain only unique items
+arr.contains(item: 3)  # returns true if 3 is present, false otherwise
+arr.remove(item: 3)  # removes the item specified from the list
+arr.replace(item: 3 by: 4)  # replaces all occurrences of the item '3' with '4'
+```
+
+### Maps
+
+```coffeescript
+m = {'a': 1, 'b': 2}
+m.length()  # returns the size of the map, 2 in this case
+m.keys()  # returns a list of all keys
+m.values()  # returns a list of all values
+m.flatten()  # returns a list of key/value pairs (eg: [['a', 1], ['b', 2]])
+m.pop(key: 'a') # removes and returns the value for key 'a'
+m.get(key: 'b' default: '.' ) # returns the value for the key 'b' with a 'default' value if the 'key' doesn't exist
+m.contains(key: 'c') # returns true if the key 'c' exists in the map, false otherwise
+m.contains(value: 'c') # returns true if the value 'c' exists in the map, false otherwise
+```
+
+### Chaining built-ins
+
+Built-ins can be chained to help reduce complexity.
+
+```coffeescript
+'abc'.uppercase().split()
+# >>> ['A', 'B', 'C']
+```


### PR DESCRIPTION
We recently realized that all most all of the 'mutations' don't actually mutate, so here's my proposal to rename them as built-ins.

I also changed the syntax to the new mutation syntax-  valid Storyscript since 0.19.0.
Furthermore:
- I changed the term 'array' to 'list' as all other parts of the documentation use this term.
- Updated the built-ins according to their current implementation in SS / engine

See also:
- https://github.com/storyscript/storyscript/releases/tag/0.19.0
- https://github.com/storyscript/storyscript/blob/master/storyscript/compiler/semantics/functions/HubMutations.py (current list of all supported mutations)

I left the float mutations out as the engine doesn't support them yet.