### PR TITLE
fix(langs): rename shell to bash

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -10,7 +10,7 @@ To get started install the Storyscript CLI ([Contribute](https://github.com/stor
 <td style="text-align:center" width="50%" valign="top">
 <h1><img src="../assets/apple-logo.svg" width="24"> macOS</h1>
 
-```shell
+```bash
 brew install storyscript/brew/story
 ```
 
@@ -30,7 +30,7 @@ Download the appropriate installer:
 <td style="text-align:center" valign="top">
 <h1><img src="../assets/ubuntu-logo.svg" width="24"> Ubuntu 16+</h1>
 
-```shell
+```bash
 sudo snap install story
 ```
 
@@ -44,7 +44,7 @@ sudo snap install story
 <td style="text-align:center" valign="top">
 <h1>Python</h1>
 
-```shell
+```bash
 pip install --user story
 ```
 
@@ -59,7 +59,7 @@ The other installation methods listed are recommended.
 
 Get a fill list of CLI commands by calling `story`.
 
-```shell
+```bash
 story
 ```
 

--- a/quick-start/README.md
+++ b/quick-start/README.md
@@ -23,7 +23,7 @@ First, install our CLI:
 <details :open="$page.os === 'macos'">
 <summary><h4><img src="../assets/apple-logo.svg" width="15"> macOS</h4></summary>
 
-```shell
+```bash
 brew install storyscript/brew/story
 ```
 
@@ -48,7 +48,7 @@ Download the appropriate installer:
 <details :open="$page.os === 'unix' || $page.os === 'linux'">
 <summary><h4><img src="../assets/ubuntu-logo.svg" width="15"> Ubuntu 16+</h4></summary>
 
-```shell
+```bash
 sudo snap install story
 ```
 
@@ -64,7 +64,7 @@ sudo snap install story
 <details :open="$page.os === 'unknown'">
 <summary><h4>Direct from Python</h4></summary>
 
-```shell
+```bash
 pip install --user story
 ```
 
@@ -78,7 +78,7 @@ The other installation methods listed are recommended.
 
 Next, login with your GitHub account:
 
-```shell
+```bash
 story login
 ```
 
@@ -92,10 +92,10 @@ If you're having trouble logging in via GitHub, please [reach out to us](http://
 ## Write your first Story
 
 Let's create your first application, to be able to check out the samples which are bundled.
-```shell
+```bash
 mkdir first_app && cd first_app
 ```
-```shell
+```bash
 story apps create
 ```
 
@@ -103,13 +103,13 @@ story apps create
 
 We have created a few examples that can help you bootstrap your project: Let's start you off with a simple hello world serverless http endpoint:
 
-```shell
+```bash
 story write http > http.story
 ```
 
 Let's take a look:
 
-```shell
+```bash
 cat http.story
 ```
 
@@ -120,7 +120,7 @@ when http server listen method: 'get' path: '/' as request
 
 Now, let's deploy your story:
 
-```shell
+```bash
 story deploy
 ```
 ```text
@@ -149,7 +149,7 @@ It will indicate where your story was deployed.
 ## Deploy changes
 
 Ready to redeploy your application? Simply run the same `deploy` command again:
-```shell
+```bash
 story deploy
 ```
 

--- a/storyscript/services/README.md
+++ b/storyscript/services/README.md
@@ -84,7 +84,7 @@ This allows this to shorten the example from above:
 Environment variables are stored in a restricted keyword `app.secrets`.
 
 Set secrets with the Storyscript CLI
-```shell
+```bash
 story config set foo=bar
 ```
 
@@ -106,7 +106,7 @@ Many services require environment variables, such as oauth tokens and client id/
 Service variables are ALWAYS unique to that service and cannot be accessed by any other service or within Storyscript secrets.
 
 Set secrets with the Storyscript CLI
-```shell
+```bash
 story config set twitter.client_id=abc123
 ```
 

--- a/storyscript/writing/README.md
+++ b/storyscript/writing/README.md
@@ -65,7 +65,7 @@ http server as client
 
 Now, instead of responding with `Hello, world!`, we're going to respond with the output of `awesome id`, which takes no parameters. It simply returns a modern uuid-esque string, which you can see in Storyscript Cloud as the app identifiers.
 
-```shell
+```bash
 curl https://….storyscriptapps.com/
 ```
 ```


### PR DESCRIPTION
As the `shell` lang doesn't exist, I've renames the existing `shell` to `bash` to prevent warnings and add highlighting to those sections