### PR TITLE
chore(CI): Add netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  publish = ".vuepress/dist"
+  command = "vuepress build && yarn run postbuild"


### PR DESCRIPTION
The default builds under directory `docs` and the front-page
is 404.

The custom values in the main repo are not visible to potential
contributors, so store them in the repository to encourage forking.